### PR TITLE
Use checkv2 endpoint

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,8 @@
+# 1.1.0 - 2018-01-12
+
+- use /checkv2 endpoint (requires rspamd 1.6+)
+- support setting SMTP message from rspamd
+- support 'rewrite subject' action
 
 # 1.0.0 - 201_-__-__
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ rspamd.ini
     Possible values are:
 
         "always" - always add headers
-        "never" - never add headers (unless provided by rspamd - see rmilter\_headers)
+        "never" - never add headers (unless provided by rspamd - see rmilter_headers)
         "sometimes" - add headers when rspamd recommends `add header` action
 
     Format of these headers is governed by header.* settings
@@ -93,11 +93,23 @@ rspamd.ini
 
     If set, add the numeric spam score in a header with this name.
 
-- rmilter_headers.enabled
+- rewrite\_subject.enabled
 
     Default: true
 
-    If set to true, allow rspamd to add/remove headers to messages via [task:rmilter_set_reply()](https://rspamd.com/doc/lua/task.html#me7351).
+    If set to true, "rewrite subject" action is honored.
+
+- rmilter\_headers.enabled
+
+    Default: true
+
+    If set to true, allow rspamd to add/remove headers to messages via [task:set_milter_reply()](https://rspamd.com/doc/lua/task.html#m70081).
+
+- smtp\_message.enabled
+
+    Default: true
+
+    If set to true, "smtp_message" provided by Rspamd is used in response for "reject" & "soft reject" actions.
 
 - soft\_reject.enabled
 
@@ -128,6 +140,12 @@ rspamd.ini
     Default: /
 
     Used as character for visual spam-level where score is zero.
+
+- subject
+
+    Default: [SPAM] %s
+
+    Subject to use for `rewrite subject` action if Rspamd does not provide one.
 
 - timeout (in seconds)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-rspamd",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Haraka plugin for rspamd",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -54,8 +54,8 @@ exports.add_headers = {
     'adds a header to a message with positive score': function (test) {
         test.expect(3);
         const test_data = {
-            default: {
-                score: 1.1,
+            score: 1.1,
+            symbols: {
                 FOO: {
                     name: 'FOO',
                     score: 0.100000,
@@ -78,9 +78,7 @@ exports.add_headers = {
     'adds a header to a message with negative score': function (test) {
         test.expect(2);
         const test_data = {
-            default: {
-                score: -1,
-            }
+            score: -1
         };
         this.plugin.add_headers(this.connection, test_data);
         // console.log(this.connection.transaction.header);
@@ -96,7 +94,7 @@ exports.wants_headers_added = {
         test.expect(1);
         this.plugin.cfg.main.add_headers='never';
         test.equal(
-            this.plugin.wants_headers_added({ default: { action: 'add header' }}),
+            this.plugin.wants_headers_added({ action: 'add header' }),
             false
         );
         test.done();
@@ -105,7 +103,7 @@ exports.wants_headers_added = {
         test.expect(1);
         this.plugin.cfg.main.add_headers='always';
         test.equal(
-            this.plugin.wants_headers_added({ default: { action: 'beat it' }}),
+            this.plugin.wants_headers_added({ action: 'beat it' }),
             true
         );
         test.done();
@@ -114,11 +112,11 @@ exports.wants_headers_added = {
         test.expect(2);
         this.plugin.cfg.main.add_headers='sometimes';
         test.equal(
-            this.plugin.wants_headers_added({ default: { action: 'add header' }}),
+            this.plugin.wants_headers_added({ action: 'add header' }),
             true
         );
         test.equal(
-            this.plugin.wants_headers_added({ default: { action: 'brownlist' }}),
+            this.plugin.wants_headers_added({ action: 'brownlist' }),
             false
         );
         test.done();


### PR DESCRIPTION
Changes proposed in this pull request:
- Support 'smtp_message'
- Support 'rewrite subject' action
- Use /checkv2 endpoint (needs rspamd 1.6+)

Checklist:
- [X] docs updated
- [X] tests updated
- [ ] Changes.md updated
- [ ] package.json.version bumped
- [ ] published to NPM (will be done by @core)