### PR TITLE
Add check.local_ip config option

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+## 1.1.2 - 2018-11-03
+
+- add check.local_ip config option
 
 ## 1.1.1 - 2018-05-10
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,13 @@ rspamd.ini
     If false, messages from private IPs will not be scanned by Rspamd.
     If true, messages from private IPs will be scanned by Rspamd.
 
+- check.local\_ip
+
+    Default: false
+
+    If false, messages from localhost will not be scanned by Rspamd.
+    If true, messages from localhost will be scanned by Rspamd.
+
 - dkim.enabled
 
     Default: true

--- a/config/rspamd.ini
+++ b/config/rspamd.ini
@@ -13,6 +13,7 @@ score = X-Rspamd-Score
 [check]
 ;authenticated=false
 ;private_ip=false
+;local_ip=false
 
 [reject]
 ;message = Detected as spam

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ exports.load_rspamd_ini = function () {
             '-check.authenticated',
             '+dkim.enabled',
             '-check.private_ip',
-            '-check.localhost',
+            '-check.local_ip',
             '+reject.spam',
             '-reject.authenticated',
             '+rewrite_subject.enabled',

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ exports.load_rspamd_ini = function () {
             '-check.authenticated',
             '+dkim.enabled',
             '-check.private_ip',
+            '-check.localhost',
             '+reject.spam',
             '-reject.authenticated',
             '+rewrite_subject.enabled',
@@ -259,6 +260,8 @@ exports.wants_skip = function (connection) {
     const plugin = this;
 
     if (!plugin.cfg.check.authenticated && connection.notes.auth_user) return true;
+
+    if (connection.remote.is_local) return !plugin.cfg.check.local_ip;
 
     if (!plugin.cfg.check.private_ip && connection.remote.is_private) return true;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-rspamd",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Haraka plugin for rspamd",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -144,3 +144,61 @@ exports.parse_response = {
         test.done();
     },
 }
+
+exports.skip = {
+    setUp : _set_up,
+    'skip authenticated': function (test) {
+        this.connection.notes.auth_user = "username";
+        this.plugin.cfg.check.authenticated = false;
+
+        test.expect(1);
+        test.equal(this.plugin.wants_skip(this.connection), true);
+        test.done();
+    },
+    'don\'t skip unauthenticated and public ip': function (test) {
+        this.connection.remote.is_local = false;
+        this.connection.remote.is_private = false;
+        this.connection.notes.auth_user = undefined;
+
+        this.plugin.cfg.check.local_ip = false;
+        this.plugin.cfg.check.private_ip = false;
+        this.plugin.cfg.check.authenticated = false;
+
+        test.expect(1);
+        test.equal(this.plugin.wants_skip(this.connection), false);
+        test.done();
+    },
+    'skip localhost if check.local_ip = false and check.private_ip = true': function (test) {
+        this.connection.remote.is_local = true;
+        this.connection.remote.is_private = true;
+
+        this.plugin.cfg.check.local_ip = false;
+        this.plugin.cfg.check.private_ip = true;
+
+        test.expect(1);
+        test.equal(this.plugin.wants_skip(this.connection), true);
+        test.done();
+    },
+    'don\'t skip localhost if check.local_ip = true and check.private_ip = true': function (test) {
+        this.connection.remote.is_local = true;
+        this.connection.remote.is_private = true;
+
+        this.plugin.cfg.check.local_ip = true;
+        this.plugin.cfg.check.private_ip = true;
+
+        test.expect(1);
+        test.equal(this.plugin.wants_skip(this.connection), false);
+        test.done();
+    },
+    'don\'t skip localhost if check.local_ip = true and check.private_ip = false': function (test) {
+        this.connection.remote.is_local = true;
+        this.connection.remote.is_private = true;
+
+        this.plugin.cfg.check.local_ip = true;
+        this.plugin.cfg.check.private_ip = false;
+
+        test.expect(1);
+        test.equal(this.plugin.wants_skip(this.connection), false);
+        test.done();
+    },
+}


### PR DESCRIPTION
Changes proposed in this pull request:
- add check.local_ip flag to allow skipping scaning localhost emails

(depends on https://github.com/haraka/Haraka/pull/2532)

Checklist:
- [x] docs updated
- [x] tests updated
- [x] Changes.md updated
- [x] package.json.version bumped
- [ ] published to NPM (will be done by @core)
