### PR TITLE
Support connecting to rspamd via unix socket

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+## 1.1.6 - 2020-02-29
+
+- Allow connecting to rspamd via unix sockets
 
 ## 1.1.5 - 2019-04-01
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ rspamd.ini
 
     Port Rspamd is listening on.
 
+- unix_socket
+
+    Path to a unix socket to connect to.  If set, overrides host and port.
+
 - add\_headers
 
     Default: sometimes

--- a/config/rspamd.ini
+++ b/config/rspamd.ini
@@ -1,5 +1,6 @@
 ;host = localhost
 ;port = 11333
+;unix_socket = /path/to/your/rspamd-client.sock
 ;add_headers = sometimes
 
 [dkim]

--- a/index.js
+++ b/index.js
@@ -67,11 +67,16 @@ exports.get_options = function (connection) {
     // https://github.com/vstakhov/rspamd/blob/master/rules/http_headers.lua
     const options = {
         headers: {},
-        port: plugin.cfg.main.port,
-        host: plugin.cfg.main.host,
         path: '/checkv2',
         method: 'POST',
     };
+
+    if (plugin.cfg.main.unix_socket) {
+        options.socketPath = plugin.cfg.main.unix_socket;
+    } else {
+        options.port = plugin.cfg.main.port;
+        options.host = plugin.cfg.main.host;
+    }
 
     if (connection.notes.auth_user) {
         options.headers.User = connection.notes.auth_user;

--- a/index.js
+++ b/index.js
@@ -73,7 +73,8 @@ exports.get_options = function (connection) {
 
     if (plugin.cfg.main.unix_socket) {
         options.socketPath = plugin.cfg.main.unix_socket;
-    } else {
+    }
+    else {
         options.port = plugin.cfg.main.port;
         options.host = plugin.cfg.main.host;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-rspamd",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Haraka plugin for rspamd",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add a `unix_socket` option to the configuration, allowing use of an rspamd instance that's listening on a unix socket, rather than a ip/port socket.

Checklist:
- [x] docs updated
- [x] tests updated  (n/a)
- [x] Changes.md updated
- [x] package.json.version bumped
- [ ] published to NPM (will be done by @core)
