### PR TITLE
fix: strip invalid bytes from MAIL FROM address

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ exports.load_rspamd_ini = function () {
     },
     () => {
       plugin.load_rspamd_ini()
-    },
+    }
   )
 
   if (!this.cfg.reject.message) {
@@ -109,7 +109,10 @@ exports.get_options = function (connection) {
   }
 
   if (connection.transaction.mail_from) {
-    const mfaddr = connection.transaction.mail_from.address().toString()
+    let mfaddr = connection.transaction.mail_from.address().toString()
+
+    mfaddr = mfaddr.replace(/\uFFFD/g, '') // Replace wrong bytes (�)
+
     if (mfaddr) {
       options.headers.From = mfaddr
     }
@@ -180,7 +183,7 @@ exports.do_milter_headers = function (connection, data) {
     try {
       connection.logdebug(
         this,
-        `milter.add_headers: ${JSON.stringify(data.milter.add_headers)}`,
+        `milter.add_headers: ${JSON.stringify(data.milter.add_headers)}`
       )
       for (const key of Object.keys(data.milter.add_headers)) {
         const header_values = data.milter.add_headers[key]
@@ -267,8 +270,8 @@ exports.hook_data_post = function (next, connection) {
           DENYSOFT,
           DSN.sec_unauthorized(
             smtp_message || plugin.cfg.soft_reject.message,
-            451,
-          ),
+            451
+          )
         )
       } else if (plugin.wants_reject(connection, r.data)) {
         nextOnce(DENY, smtp_message || plugin.cfg.reject.message)
@@ -457,7 +460,7 @@ exports.add_headers = function (connection, data) {
     connection.transaction.remove_header(cfg.header.report)
     connection.transaction.add_header(
       cfg.header.report,
-      prettySymbols.join(' '),
+      prettySymbols.join(' ')
     )
   }
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ exports.load_rspamd_ini = function () {
     },
     () => {
       plugin.load_rspamd_ini()
-    }
+    },
   )
 
   if (!this.cfg.reject.message) {
@@ -183,7 +183,7 @@ exports.do_milter_headers = function (connection, data) {
     try {
       connection.logdebug(
         this,
-        `milter.add_headers: ${JSON.stringify(data.milter.add_headers)}`
+        `milter.add_headers: ${JSON.stringify(data.milter.add_headers)}`,
       )
       for (const key of Object.keys(data.milter.add_headers)) {
         const header_values = data.milter.add_headers[key]
@@ -270,8 +270,8 @@ exports.hook_data_post = function (next, connection) {
           DENYSOFT,
           DSN.sec_unauthorized(
             smtp_message || plugin.cfg.soft_reject.message,
-            451
-          )
+            451,
+          ),
         )
       } else if (plugin.wants_reject(connection, r.data)) {
         nextOnce(DENY, smtp_message || plugin.cfg.reject.message)
@@ -460,7 +460,7 @@ exports.add_headers = function (connection, data) {
     connection.transaction.remove_header(cfg.header.report)
     connection.transaction.add_header(
       cfg.header.report,
-      prettySymbols.join(' ')
+      prettySymbols.join(' '),
     )
   }
 


### PR DESCRIPTION
Changes proposed in this pull request:

- Fixes errors when the mail_from address has incorrect utf-8 bytes which are later replaced with utf-8 placeholder symbol
- Fixes code style

In general as the values are used as http headers I would recommend to check for incorrect utf-8 bytes and, as a minimum, remove them.
The exact issue that was encountered is that when receiving an email from an address that for some reason had incorrect utf-8 bytes the plugin resulted in `[core] Plugin rspamd failed: TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["From"]` error.
