### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+### [1.5.0] - 2026-05-10
+
+- feat: add HTTPS support with configurable TLS options
+- feat: move more protocol handing into rspamd.ini
+- feat: expanded protocol-level control over requests
+  - Settings-ID, Settings, Flags, Pass, Raw, URL-Format, etc
+- refactor: reduce complexity, use ES2024 idioms
+- fix(get_clean): preserve messages dictionary, was discarding the join result
+- fix(do_milter_headers):
+  - logerror typo (was errorlog)
+  - move JSON.stringify into try so circular references don't crash
+
 ### [1.4.3] - 2026-05-10
 
 - call message_stream.unpipe before next
@@ -113,3 +125,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 [1.4.0]: https://github.com/haraka/haraka-plugin-rspamd/releases/tag/v1.4.0
 [1.4.2]: https://github.com/haraka/haraka-plugin-rspamd/releases/tag/v1.4.2
 [1.4.3]: https://github.com/haraka/haraka-plugin-rspamd/releases/tag/v1.4.3
+[1.5.0]: https://github.com/haraka/haraka-plugin-rspamd/releases/tag/v1.5.0

--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ rspamd.ini
 
   Path to a unix socket to connect to. If set, overrides host and port.
 
+- scheme
+
+  Default: http
+
+  Transport for network connections (`http` or `https`). Ignored when
+  `unix_socket` is set.
+
+- path
+
+  Default: /checkv2
+
+  HTTP path for rspamd checks.
+
 - add_headers
 
   Default: sometimes
@@ -36,6 +49,89 @@ rspamd.ini
         "sometimes" - add headers when rspamd recommends `add header` action
 
   Format of these headers is governed by header.\* settings
+
+- tls.reject_unauthorized
+
+  Default: true
+
+  TLS certificate verification setting for HTTPS upstream requests.
+
+- tls.servername
+
+  Default: undefined
+
+  Optional TLS SNI override when connecting via HTTPS.
+
+- tls.ca_file / tls.cert_file / tls.key_file
+
+  Default: undefined
+
+  Optional PEM files for CA trust, client certificate, and client key when
+  using HTTPS.
+
+- auth.basic_user / auth.basic_pass
+
+  Default: undefined
+
+  Optional HTTP Basic Auth credentials for protected rspamd endpoints.
+
+- auth.header / auth.value / auth.value_env
+
+  Default: undefined
+
+  Optional custom auth header. `auth.value_env` reads the header value from an
+  environment variable.
+
+- request.settings_id
+
+  Default: undefined
+
+  Sends `Settings-ID` header so rspamd can apply a named profile (for example,
+  an URIBL-focused profile in `settings.conf`).
+
+- request.settings
+
+  Default: undefined
+
+  Sends raw `Settings` header payload for per-request rspamd settings overrides.
+
+- request.flags
+
+  Default: undefined
+
+  Comma-separated `Flags` header value for rspamd protocol options.
+
+- request.body_block / request.ext_urls / request.groups / request.milter /
+  request.no_log / request.profile / request.skip / request.skip_process /
+  request.zstd
+
+  Default: false
+
+  Boolean helpers that append protocol flags to `Flags`.
+
+- request.pass_all
+
+  Default: false
+
+  Sends `Pass: all` to force all rspamd filters for a request.
+
+- request.raw
+
+  Default: false
+
+  Sends `Raw: yes` for non-MIME/raw body scanning.
+
+- request.url_format
+
+  Default: undefined
+
+  Sets rspamd `URL-Format` header (for example, `extended`).
+
+- request_headers.\*
+
+  Default: undefined
+
+  Additional headers to pass to rspamd (for example, `MTA-Tag`).
 
 - reject.message
 

--- a/config/rspamd.ini
+++ b/config/rspamd.ini
@@ -1,7 +1,36 @@
 ;host = localhost
 ;port = 11333
+;scheme = http
+;path = /checkv2
 ;unix_socket = /path/to/your/rspamd-client.sock
 ;add_headers = sometimes
+
+[tls]
+;reject_unauthorized = true
+;servername = rspamd.example.com
+;ca_file = /path/to/ca.pem
+;cert_file = /path/to/client-cert.pem
+;key_file = /path/to/client-key.pem
+
+[auth]
+;basic_user = user
+;basic_pass = password
+;header = Authorization
+;value = Bearer token
+;value_env = RSPAMD_AUTH_HEADER
+
+[request]
+;settings_id = uribl
+;settings = {"groups_enabled":["surbl"]}
+;flags = groups,milter
+;ext_urls = true
+;pass_all = false
+;raw = false
+;url_format = extended
+
+[request_headers]
+;MTA-Tag = outbound
+;X-API-Key = abc123
 
 [dkim]
 ;enabled = true

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict'
 
 // node built-ins
+const fs = require('node:fs')
 const http = require('node:http')
+const https = require('node:https')
 
 // haraka libs
 const DSN = require('haraka-dsn')
@@ -10,140 +12,212 @@ exports.register = function () {
   this.load_rspamd_ini()
 }
 
-exports.load_rspamd_ini = function () {
-  const plugin = this
+const INI_BOOLEANS = [
+  '-check.authenticated',
+  '+dkim.enabled',
+  '-check.private_ip',
+  '-check.local_ip',
+  '-check.relay',
+  '+reject.spam',
+  '-reject.authenticated',
+  '+rewrite_subject.enabled',
+  '+rmilter_headers.enabled',
+  '+soft_reject.enabled',
+  '+smtp_message.enabled',
+  '-defer.error',
+  '-defer.timeout',
+  '-request.pass_all',
+  '-request.body_block',
+  '-request.groups',
+  '-request.milter',
+  '-request.no_log',
+  '-request.profile',
+  '-request.skip',
+  '-request.skip_process',
+  '-request.zstd',
+  '-request.ext_urls',
+  '-request.raw',
+  '+tls.reject_unauthorized',
+]
 
-  plugin.cfg = plugin.config.get(
-    'rspamd.ini',
-    {
-      booleans: [
-        '-check.authenticated',
-        '+dkim.enabled',
-        '-check.private_ip',
-        '-check.local_ip',
-        '-check.relay',
-        '+reject.spam',
-        '-reject.authenticated',
-        '+rewrite_subject.enabled',
-        '+rmilter_headers.enabled',
-        '+soft_reject.enabled',
-        '+smtp_message.enabled',
-        '-defer.error',
-        '-defer.timeout',
-      ],
-    },
-    () => {
-      plugin.load_rspamd_ini()
-    },
+exports.load_rspamd_ini = function () {
+  this.cfg = this.config.get('rspamd.ini', { booleans: INI_BOOLEANS }, () =>
+    this.load_rspamd_ini(),
   )
 
-  if (!this.cfg.reject.message) {
-    this.cfg.reject.message = 'Detected as spam'
-  }
-
-  if (!this.cfg.soft_reject.message) {
-    this.cfg.soft_reject.message = 'Deferred by policy'
-  }
-
-  if (!this.cfg.spambar) {
-    this.cfg.spambar = { positive: '+', negative: '-', neutral: '/' }
-  }
-
-  if (!this.cfg.main.port) this.cfg.main.port = 11333
-  if (!this.cfg.main.host) this.cfg.main.host = 'localhost'
-
-  if (!this.cfg.main.add_headers) {
-    if (this.cfg.main.always_add_headers === true) {
-      this.cfg.main.add_headers = 'always'
-    } else {
-      this.cfg.main.add_headers = 'sometimes'
-    }
-  }
-
-  if (!this.cfg.subject) {
-    this.cfg.subject = '[SPAM] %s'
-  }
+  this.cfg.reject.message ??= 'Detected as spam'
+  this.cfg.soft_reject.message ??= 'Deferred by policy'
+  this.cfg.spambar ??= { positive: '+', negative: '-', neutral: '/' }
+  this.cfg.main.host ??= 'localhost'
+  this.cfg.main.port ??= 11333
+  this.cfg.main.path ??= '/checkv2'
+  this.cfg.main.scheme ??= 'http'
+  this.cfg.subject ??= '[SPAM] %s'
+  this.cfg.main.add_headers ??=
+    this.cfg.main.always_add_headers === true ? 'always' : 'sometimes'
+  this.cfg.tls ??= {}
+  this.cfg.tls.reject_unauthorized ??= true
+  this.cfg.request ??= {}
 }
 
 exports.get_options = function (connection) {
-  // https://rspamd.com/doc/architecture/protocol.html
-  // https://github.com/vstakhov/rspamd/blob/master/rules/http_headers.lua
-  const options = {
-    headers: {},
-    path: '/checkv2',
-    method: 'POST',
-  }
-
-  if (this.cfg.main.unix_socket) {
-    options.socketPath = this.cfg.main.unix_socket
-  } else {
-    options.port = this.cfg.main.port
-    options.host = this.cfg.main.host
-  }
-
-  if (connection.notes.auth_user) {
-    options.headers.User = connection.notes.auth_user
-  }
-
-  if (connection.remote.ip) options.headers.IP = connection.remote.ip
-
-  const fcrdns = connection.results.get('fcrdns')
-  if (fcrdns && fcrdns.fcrdns && fcrdns.fcrdns[0]) {
-    options.headers.Hostname = fcrdns.fcrdns[0]
-  } else {
-    if (connection.remote.host) {
-      options.headers.Hostname = connection.remote.host
-    }
-  }
-
-  if (connection.hello.host) options.headers.Helo = connection.hello.host
-
-  let spf = connection.transaction.results.get('spf')
-  if (spf && spf.result) {
-    options.headers.SPF = { result: spf.result.toLowerCase() }
-  } else {
-    spf = connection.results.get('spf')
-    if (spf && spf.result) {
-      options.headers.SPF = { result: spf.result.toLowerCase() }
-    }
-  }
-
-  if (connection.transaction.mail_from) {
-    const mfaddr = connection.transaction.mail_from.address().toString()
-
-    if (mfaddr) options.headers.From = mfaddr
-  }
-
-  const rcpts = connection.transaction.rcpt_to
-  if (rcpts) {
-    options.headers.Rcpt = []
-    for (const rcpt of rcpts) {
-      options.headers.Rcpt.push(rcpt.address())
-    }
-
-    // for per-user options
-    if (rcpts.length === 1) {
-      options.headers['Deliver-To'] = options.headers.Rcpt[0]
-    }
-  }
-
-  if (connection.transaction.uuid)
-    options.headers['Queue-Id'] = connection.transaction.uuid
-
-  if (connection.tls.enabled) {
-    options.headers['TLS-Cipher'] = connection.tls.cipher.name
-    options.headers['TLS-Version'] = connection.tls.cipher.version
-  }
-
+  // https://docs.rspamd.com/developers/protocol
+  // https://github.com/rspamd/rspamd/blob/master/rules/headers_checks.lua
+  const options = { headers: {}, path: this.cfg.main.path, method: 'POST' }
+  set_transport(options, this.cfg)
+  set_protocol(options, this.cfg)
+  set_auth(options, connection)
+  set_remote(options, connection)
+  set_spf(options, connection)
+  set_envelope(options, connection)
+  set_tls(options, connection)
+  set_upstream_auth(options, this.cfg)
+  set_custom_headers(options, this.cfg)
   return options
 }
 
-exports.get_smtp_message = function (r) {
-  if (!this.cfg.smtp_message.enabled || !r.data.messages) return
-  if (typeof r.data.messages !== 'object') return
-  if (!r.data.messages.smtp_message) return
+function set_transport(options, cfg) {
+  if (cfg.main.unix_socket) {
+    options.socketPath = cfg.main.unix_socket
+    return
+  }
 
-  return r.data.messages.smtp_message
+  options.host = cfg.main.host
+  options.port = cfg.main.port
+  if (get_scheme(cfg) === 'https') {
+    options.protocol = 'https:'
+    set_https_transport(options, cfg)
+  } else {
+    options.protocol = 'http:'
+  }
+}
+
+function get_scheme(cfg) {
+  const scheme = cfg.main.scheme?.toLowerCase()
+  return scheme === 'https' ? 'https' : 'http'
+}
+
+function set_https_transport(options, cfg) {
+  const tls = cfg.tls ?? {}
+  options.rejectUnauthorized = tls.reject_unauthorized !== false
+  if (tls.servername) options.servername = tls.servername
+  if (tls.ca_file) options.ca = fs.readFileSync(tls.ca_file)
+  if (tls.cert_file) options.cert = fs.readFileSync(tls.cert_file)
+  if (tls.key_file) options.key = fs.readFileSync(tls.key_file)
+}
+
+function set_protocol(options, cfg) {
+  const req = cfg.request ?? {}
+  if (req.settings_id) options.headers['Settings-ID'] = req.settings_id
+  if (req.settings) options.headers.Settings = req.settings
+  if (req.pass_all) options.headers.Pass = 'all'
+  if (req.raw) options.headers.Raw = 'yes'
+
+  const flags = get_flags(req)
+  if (flags.length) options.headers.Flags = flags.join(',')
+  if (req.url_format) options.headers['URL-Format'] = req.url_format
+}
+
+function get_flags(req) {
+  const flags = new Set(parse_flags(req.flags))
+  const bool_flags = {
+    body_block: req.body_block,
+    ext_urls: req.ext_urls,
+    groups: req.groups,
+    milter: req.milter,
+    no_log: req.no_log,
+    profile: req.profile,
+    skip: req.skip,
+    skip_process: req.skip_process,
+    zstd: req.zstd,
+  }
+  for (const [flag, enabled] of Object.entries(bool_flags)) {
+    if (enabled) flags.add(flag)
+  }
+  return [...flags]
+}
+
+function parse_flags(raw) {
+  if (Array.isArray(raw)) return raw.map((v) => `${v}`.trim()).filter((v) => v)
+  if (typeof raw !== 'string') return []
+  return raw
+    .split(',')
+    .map((v) => v.trim())
+    .filter((v) => v)
+}
+
+function set_upstream_auth(options, cfg) {
+  const auth = cfg.auth ?? {}
+  if (auth.basic_user) {
+    const auth_pass = auth.basic_pass ?? ''
+    const token = Buffer.from(`${auth.basic_user}:${auth_pass}`).toString(
+      'base64',
+    )
+    options.headers.Authorization = `Basic ${token}`
+  }
+
+  if (!auth.header) return
+  const env_value = auth.value_env ? process.env[auth.value_env] : undefined
+  const header_value = env_value ?? auth.value
+  if (header_value) options.headers[auth.header] = header_value
+}
+
+function set_custom_headers(options, cfg) {
+  const headers = cfg.request_headers
+  if (!headers || typeof headers !== 'object') return
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (!value) continue
+    options.headers[key] = `${value}`
+  }
+}
+
+function set_auth(options, connection) {
+  if (connection.notes.auth_user)
+    options.headers.User = connection.notes.auth_user
+}
+
+function set_remote(options, connection) {
+  if (connection.remote.ip) options.headers.IP = connection.remote.ip
+  const fcrdns = connection.results.get('fcrdns')
+  const host = fcrdns?.fcrdns?.[0] ?? connection.remote.host
+  if (host) options.headers.Hostname = host
+  if (connection.hello.host) options.headers.Helo = connection.hello.host
+}
+
+function set_spf(options, connection) {
+  const spf =
+    connection.transaction.results.get('spf') ?? connection.results.get('spf')
+  if (spf?.result) options.headers.SPF = { result: spf.result.toLowerCase() }
+}
+
+function set_envelope(options, connection) {
+  const txn = connection.transaction
+  const from = txn.mail_from?.address()?.toString()
+  if (from) options.headers.From = from
+
+  const rcpts = txn.rcpt_to
+  if (rcpts?.length) {
+    options.headers.Rcpt = rcpts.map((r) => r.address())
+    // for per-user options
+    if (rcpts.length === 1)
+      options.headers['Deliver-To'] = options.headers.Rcpt[0]
+  }
+
+  if (txn.uuid) options.headers['Queue-Id'] = txn.uuid
+}
+
+function set_tls(options, connection) {
+  if (!connection.tls.enabled) return
+  options.headers['TLS-Cipher'] = connection.tls.cipher.name
+  options.headers['TLS-Version'] = connection.tls.cipher.version
+}
+
+exports.get_smtp_message = function (r) {
+  if (!this.cfg.smtp_message.enabled) return
+  const messages = r?.data?.messages
+  if (!messages || typeof messages !== 'object') return
+  return messages.smtp_message
 }
 
 exports.do_rewrite = function (connection, data) {
@@ -167,175 +241,179 @@ exports.add_dkim_header = function (connection, data) {
 
 exports.do_milter_headers = function (connection, data) {
   if (!this.cfg.rmilter_headers.enabled) return
-  if (!data.milter) return
+  if (!data?.milter) return
 
-  if (data.milter.remove_headers) {
-    for (const key of Object.keys(data.milter.remove_headers)) {
-      connection.transaction.remove_header(key)
-    }
+  const { remove_headers, add_headers } = data.milter
+  const txn = connection.transaction
+
+  if (remove_headers) {
+    for (const key of Object.keys(remove_headers)) txn.remove_header(key)
   }
 
-  if (data.milter.add_headers) {
-    try {
-      connection.logdebug(
-        this,
-        `milter.add_headers: ${JSON.stringify(data.milter.add_headers)}`,
-      )
-      for (const key of Object.keys(data.milter.add_headers)) {
-        const header_values = data.milter.add_headers[key]
-        if (!header_values) continue
+  if (!add_headers) return
 
-        if (Object.prototype.toString.call(header_values) == '[object Array]') {
-          header_values.forEach(function (header_value) {
-            if (typeof header_value === 'object') {
-              connection.transaction.add_header(key, header_value.value)
-            } else {
-              connection.transaction.add_header(key, header_value)
-            }
-          })
-        } else if (typeof header_values === 'object') {
-          connection.transaction.add_header(key, header_values.value)
-        } else {
-          connection.transaction.add_header(key, header_values)
-        }
+  try {
+    connection.logdebug(
+      this,
+      `milter.add_headers: ${JSON.stringify(add_headers)}`,
+    )
+    for (const [key, value] of Object.entries(add_headers)) {
+      if (value == null) continue
+      if (Array.isArray(value)) {
+        for (const v of value) add_milter_value(txn, key, v)
+      } else {
+        add_milter_value(txn, key, value)
       }
-    } catch (err) {
-      connection.errorlog(this, `milter.addheaders error: ${err}`)
     }
+  } catch (err) {
+    connection.logerror(this, `milter.add_headers error: ${err}`)
   }
+}
+
+function add_milter_value(txn, key, value) {
+  if (value && typeof value === 'object') {
+    txn.add_header(key, value.value)
+  } else {
+    txn.add_header(key, value)
+  }
+}
+
+exports.get_request_client = function (options) {
+  if (options.socketPath) return http
+  return options.protocol === 'https:' ? https : http
 }
 
 exports.hook_data_post = function (next, connection) {
   const plugin = this
-
   if (!connection.transaction) return next()
   if (!plugin.should_check(connection)) return next()
 
-  let timer
-  const timeout = plugin.cfg.main.timeout || plugin.timeout - 1
-
-  let calledNext = false
-  function nextOnce(code, msg) {
-    // unpipe() before destroy() — see haraka/message-stream#22.
-    if (connection?.transaction?.message_stream)
-      connection.transaction.message_stream.unpipe()
-    if (req) req.destroy()
-    clearTimeout(timer)
-    if (calledNext) return
-    calledNext = true
-    if (!connection?.transaction) return
-    next(code, msg)
-  }
-
-  timer = setTimeout(() => {
-    if (!connection?.transaction) return
-    connection.transaction.results.add(plugin, { err: 'timeout' })
-    if (plugin.cfg.defer.timeout)
-      return nextOnce(DENYSOFT, 'Rspamd scan timeout')
-    nextOnce()
-  }, timeout * 1000)
-
   const start = Date.now()
+  const ctx = make_request_context(plugin, connection, next)
 
-  const req = http.request(plugin.get_options(connection), (res) => {
+  ctx.timer = setTimeout(
+    () => on_timeout(plugin, connection, ctx),
+    (plugin.cfg.main.timeout || plugin.timeout - 1) * 1000,
+  )
+
+  const options = plugin.get_options(connection)
+  const request_client = plugin.get_request_client(options)
+  ctx.req = request_client.request(options, (res) => {
     let rawData = ''
-
     res.on('data', (chunk) => {
       rawData += chunk
     })
-
-    res.on('end', () => {
-      if (!connection.transaction) return nextOnce() //client gone
-
-      const r = plugin.parse_response(rawData, connection)
-      if (!r || !r.data || !r.log) {
-        if (plugin.cfg.defer.error)
-          return nextOnce(DENYSOFT, 'Rspamd scan error')
-        return nextOnce()
-      }
-
-      r.log.emit = true // spit out a log entry
-      r.log.time = (Date.now() - start) / 1000
-
-      connection.transaction.results.add(plugin, r.log)
-      if (r.data.symbols)
-        connection.transaction.results.add(plugin, { symbols: r.data.symbols })
-
-      const smtp_message = plugin.get_smtp_message(r)
-
-      plugin.do_rewrite(connection, r.data)
-
-      if (plugin.cfg.soft_reject.enabled && r.data.action === 'soft reject') {
-        nextOnce(
-          DENYSOFT,
-          DSN.sec_unauthorized(
-            smtp_message || plugin.cfg.soft_reject.message,
-            451,
-          ),
-        )
-      } else if (plugin.wants_reject(connection, r.data)) {
-        nextOnce(DENY, smtp_message || plugin.cfg.reject.message)
-      } else {
-        plugin.add_dkim_header(connection, r.data)
-        plugin.do_milter_headers(connection, r.data)
-        plugin.add_headers(connection, r.data)
-
-        nextOnce()
-      }
-    })
+    res.on('end', () => on_response(plugin, connection, ctx, rawData, start))
   })
 
-  req.on('error', (err) => {
-    if (!connection?.transaction) return nextOnce() // client gone
-    connection.transaction.results.add(plugin, { err: err.message })
-    if (plugin.cfg.defer.error) return nextOnce(DENYSOFT, 'Rspamd scan error')
-    nextOnce()
-  })
+  ctx.req.on('error', (err) => on_request_error(plugin, connection, ctx, err))
 
-  connection.transaction.message_stream.pipe(req)
+  connection.transaction.message_stream.pipe(ctx.req)
   // pipe calls req.end() asynchronously
 }
 
+function make_request_context(plugin, connection, next) {
+  const ctx = { req: null, timer: null, calledNext: false }
+  ctx.nextOnce = (code, msg) => {
+    // unpipe() before destroy() — see haraka/message-stream#22.
+    connection?.transaction?.message_stream?.unpipe()
+    if (ctx.req) ctx.req.destroy()
+    clearTimeout(ctx.timer)
+    if (ctx.calledNext) return
+    ctx.calledNext = true
+    if (!connection?.transaction) return
+    next(code, msg)
+  }
+  return ctx
+}
+
+function on_timeout(plugin, connection, ctx) {
+  if (!connection?.transaction) return
+  connection.transaction.results.add(plugin, { err: 'timeout' })
+  if (plugin.cfg.defer.timeout)
+    return ctx.nextOnce(DENYSOFT, 'Rspamd scan timeout')
+  ctx.nextOnce()
+}
+
+function on_request_error(plugin, connection, ctx, err) {
+  if (!connection?.transaction) return ctx.nextOnce() // client gone
+  connection.transaction.results.add(plugin, { err: err.message })
+  if (plugin.cfg.defer.error) return ctx.nextOnce(DENYSOFT, 'Rspamd scan error')
+  ctx.nextOnce()
+}
+
+function on_response(plugin, connection, ctx, rawData, start) {
+  if (!connection.transaction) return ctx.nextOnce() // client gone
+
+  const r = plugin.parse_response(rawData, connection)
+  if (!r?.data || !r.log) {
+    if (plugin.cfg.defer.error)
+      return ctx.nextOnce(DENYSOFT, 'Rspamd scan error')
+    return ctx.nextOnce()
+  }
+
+  r.log.emit = true // spit out a log entry
+  r.log.time = (Date.now() - start) / 1000
+  connection.transaction.results.add(plugin, r.log)
+  if (r.data.symbols)
+    connection.transaction.results.add(plugin, { symbols: r.data.symbols })
+
+  plugin.do_rewrite(connection, r.data)
+
+  const action = plugin.decide_action(connection, r)
+  if (action) return ctx.nextOnce(...action)
+
+  plugin.add_dkim_header(connection, r.data)
+  plugin.do_milter_headers(connection, r.data)
+  plugin.add_headers(connection, r.data)
+  ctx.nextOnce()
+}
+
+exports.decide_action = function (connection, r) {
+  const smtp_message = this.get_smtp_message(r)
+  if (this.cfg.soft_reject.enabled && r.data.action === 'soft reject') {
+    return [
+      DENYSOFT,
+      DSN.sec_unauthorized(smtp_message || this.cfg.soft_reject.message, 451),
+    ]
+  }
+  if (this.wants_reject(connection, r.data)) {
+    return [DENY, smtp_message || this.cfg.reject.message]
+  }
+  return null
+}
+
 exports.should_check = function (connection) {
-  let result = true // default
+  const check = this.cfg.check
+  const remote = connection.remote
+  const skip_rules = [
+    ['authed', !check.authenticated && connection.notes.auth_user],
+    ['relay', !check.relay && connection.relaying],
+    ['local_ip', !check.local_ip && remote.is_local],
+    // local IPs are a subset of private IPs — don't double-skip
+    [
+      'private_ip',
+      !check.private_ip &&
+        remote.is_private &&
+        !(check.local_ip && remote.is_local),
+    ],
+  ]
 
-  if (this.cfg.check.authenticated == false && connection.notes.auth_user) {
-    connection.transaction.results.add(this, { skip: 'authed' })
+  let result = true
+  for (const [name, should_skip] of skip_rules) {
+    if (!should_skip) continue
+    connection.transaction.results.add(this, { skip: name })
     result = false
   }
-
-  if (this.cfg.check.relay == false && connection.relaying) {
-    connection.transaction.results.add(this, { skip: 'relay' })
-    result = false
-  }
-
-  if (this.cfg.check.local_ip == false && connection.remote.is_local) {
-    connection.transaction.results.add(this, { skip: 'local_ip' })
-    result = false
-  }
-
-  if (this.cfg.check.private_ip == false && connection.remote.is_private) {
-    if (this.cfg.check.local_ip == true && connection.remote.is_local) {
-      // local IPs are included in private IPs
-    } else {
-      connection.transaction.results.add(this, { skip: 'private_ip' })
-      result = false
-    }
-  }
-
   return result
 }
 
 exports.wants_reject = function (connection, data) {
   if (data.action !== 'reject') return false
-
-  if (connection.notes.auth_user) {
-    if (this.cfg.reject.authenticated == false) return false
-  } else {
-    if (this.cfg.reject.spam == false) return false
-  }
-
-  return true
+  const flag = connection.notes.auth_user
+    ? this.cfg.reject.authenticated
+    : this.cfg.reject.spam
+  return flag !== false
 }
 
 exports.wants_headers_added = function (rspamd_data) {
@@ -347,53 +425,41 @@ exports.wants_headers_added = function (rspamd_data) {
   return false
 }
 
+const SCALAR_TYPES = new Set(['boolean', 'number', 'string'])
+const SCALAR_KEYS = ['action', 'is_skipped', 'required_score', 'score']
+const COLLECTION_KEYS = ['urls', 'emails', 'messages']
+
 exports.get_clean = function (data, connection) {
   const clean = { symbols: {} }
 
-  if (data.symbols) {
-    Object.keys(data.symbols).forEach((key) => {
-      const a = data.symbols[key]
-      // transform { name: KEY, score: VAL } -> { KEY: VAL }
-      if (a.name && a.score !== undefined) {
-        clean.symbols[a.name] = a.score
-        return
-      }
-      // unhandled type
-      connection.logerror(this, a)
-    })
-  }
-
-  // objects that may exist
-  const skip_keys = ['action', 'is_skipped', 'required_score', 'score']
-  for (const key of skip_keys) {
-    switch (typeof data[key]) {
-      case 'boolean':
-      case 'number':
-      case 'string':
-        clean[key] = data[key]
-        break
-      default:
-        connection.loginfo(this, `skipping unhandled: ${typeof data[key]}`)
+  for (const [key, sym] of Object.entries(data.symbols ?? {})) {
+    // transform { name: KEY, score: VAL } -> { KEY: VAL }
+    if (sym?.name && sym.score !== undefined) {
+      clean.symbols[sym.name] = sym.score
+    } else {
+      connection.logerror(this, sym ?? key)
     }
   }
 
-  // arrays which might be present
-  const arrays = ['urls', 'emails', 'messages']
-  for (const b of arrays) {
-    // collapse to comma separated string, so values get logged
-    if (!data[b]) continue
-
-    if (data[b].length) {
-      clean[b] = data[b].join(',')
-      continue
+  for (const key of SCALAR_KEYS) {
+    if (data[key] === undefined) continue
+    if (SCALAR_TYPES.has(typeof data[key])) {
+      clean[key] = data[key]
+    } else {
+      connection.loginfo(this, `skipping unhandled: ${typeof data[key]}`)
     }
+  }
 
-    if (typeof data[b] == 'object') {
-      // 'messages' is probably a dictionary
-      Object.keys(data[b])
-        .map((k) => {
-          return `${k} : ${data[b][k]}`
-        })
+  // collapse to comma-separated strings so values get logged
+  for (const key of COLLECTION_KEYS) {
+    const val = data[key]
+    if (!val) continue
+    if (Array.isArray(val)) {
+      clean[key] = val.join(',')
+    } else if (typeof val === 'object') {
+      // dictionary form, e.g. messages: { smtp_message: '…' }
+      clean[key] = Object.entries(val)
+        .map(([k, v]) => `${k} : ${v}`)
         .join(',')
     }
   }
@@ -414,9 +480,9 @@ exports.parse_response = function (rawData, connection) {
     return
   }
 
-  if (Object.keys(data).length === 0) return
-
-  if (Object.keys(data).length === 1 && data.error) {
+  const keys = Object.keys(data)
+  if (keys.length === 0) return
+  if (keys.length === 1 && data.error) {
     connection.transaction.results.add(this, { err: data.error })
     return
   }
@@ -428,44 +494,38 @@ exports.parse_response = function (rawData, connection) {
 }
 
 exports.add_headers = function (connection, data) {
-  const cfg = this.cfg
-
   if (!this.wants_headers_added(data)) return
 
-  if (cfg.header && cfg.header.bar) {
-    let spamBar = ''
-    let spamBarScore = 1
-    let spamBarChar = cfg.spambar.neutral || '/'
-    if (data.score >= 1) {
-      spamBarScore = Math.floor(data.score)
-      spamBarChar = cfg.spambar.positive || '+'
-    } else if (data.score <= -1) {
-      spamBarScore = Math.floor(data.score * -1)
-      spamBarChar = cfg.spambar.negative || '-'
-    }
-    for (let i = 0; i < spamBarScore; i++) {
-      spamBar += spamBarChar
-    }
-    connection.transaction.remove_header(cfg.header.bar)
-    connection.transaction.add_header(cfg.header.bar, spamBar)
-  }
+  const { header, spambar } = this.cfg
+  if (!header) return
 
-  if (cfg.header && cfg.header.report) {
-    const prettySymbols = []
-    for (const k in data.symbols) {
-      if (data.symbols[k].score) {
-        prettySymbols.push(`${data.symbols[k].name}(${data.symbols[k].score})`)
-      }
-    }
-    connection.transaction.remove_header(cfg.header.report)
-    connection.transaction.add_header(
-      cfg.header.report,
-      prettySymbols.join(' '),
-    )
+  const txn = connection.transaction
+  const values = {
+    bar: make_spam_bar(data.score, spambar),
+    report: format_symbols(data.symbols),
+    score: `${data.score}`,
   }
+  for (const [key, name] of Object.entries(header)) {
+    if (!name || values[key] === undefined) continue
+    replace_header(txn, name, values[key])
+  }
+}
 
-  if (cfg.header && cfg.header.score) {
-    connection.transaction.remove_header(cfg.header.score)
-    connection.transaction.add_header(cfg.header.score, `${data.score}`)
+function replace_header(txn, name, value) {
+  txn.remove_header(name)
+  txn.add_header(name, value)
+}
+
+function make_spam_bar(score, spambar) {
+  if (score >= 1) return (spambar.positive || '+').repeat(Math.floor(score))
+  if (score <= -1) return (spambar.negative || '-').repeat(Math.floor(-score))
+  return spambar.neutral || '/'
+}
+
+function format_symbols(symbols) {
+  const pretty = []
+  for (const sym of Object.values(symbols ?? {})) {
+    if (sym?.score) pretty.push(`${sym.name}(${sym.score})`)
   }
+  return pretty.join(' ')
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-rspamd",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "description": "Haraka plugin for rspamd",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,9 @@
 const assert = require('node:assert')
 const fs = require('node:fs')
 const http = require('node:http')
+const https = require('node:https')
+const os = require('node:os')
+const path = require('node:path')
 const { PassThrough } = require('node:stream')
 const { afterEach, beforeEach, describe, it } = require('node:test')
 
@@ -310,6 +313,632 @@ describe('rspamd request cleanup', () => {
           () => this.connection.transaction.message_stream.pipe(dest),
           'message_stream must be free for re-pipe after timeout',
         )
+        done()
+      }, this.connection)
+    })
+  })
+})
+
+// ─── Characterization tests ──────────────────────────────────────────────────
+// These lock in current behavior of the uncovered exports prior to refactor.
+// If any assertion changes, the refactor changed observable behavior — that
+// should be intentional and reflected in the CHANGELOG.
+
+describe('get_options', () => {
+  beforeEach(_set_up)
+
+  it('uses unix_socket when configured', () => {
+    this.plugin.cfg.main.unix_socket = '/var/run/rspamd.sock'
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.socketPath, '/var/run/rspamd.sock')
+    assert.equal(opts.port, undefined)
+    assert.equal(opts.host, undefined)
+  })
+
+  it('uses host/port when no unix_socket', () => {
+    this.plugin.cfg.main.host = 'rspamd.example.com'
+    this.plugin.cfg.main.port = 11334
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.host, 'rspamd.example.com')
+    assert.equal(opts.port, 11334)
+    assert.equal(opts.socketPath, undefined)
+  })
+
+  it('sets request method and path', () => {
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.method, 'POST')
+    assert.equal(opts.path, '/checkv2')
+  })
+
+  it('supports custom request path', () => {
+    this.plugin.cfg.main.path = '/checkv3'
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.path, '/checkv3')
+  })
+
+  it('sets User header from auth_user', () => {
+    this.connection.notes.auth_user = 'bob@example.com'
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.User, 'bob@example.com')
+  })
+
+  it('sets IP header from remote.ip', () => {
+    this.connection.remote.ip = '203.0.113.5'
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.IP, '203.0.113.5')
+  })
+
+  it('prefers fcrdns Hostname over remote.host', () => {
+    this.connection.remote.host = 'fallback.example.com'
+    this.connection.results.add(
+      { name: 'fcrdns' },
+      { fcrdns: ['real.example.com'] },
+    )
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.Hostname, 'real.example.com')
+  })
+
+  it('falls back to remote.host when no fcrdns result', () => {
+    this.connection.remote.host = 'fallback.example.com'
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.Hostname, 'fallback.example.com')
+  })
+
+  it('sets Helo from hello.host', () => {
+    this.connection.hello.host = 'helo.example.com'
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.Helo, 'helo.example.com')
+  })
+
+  it('SPF from transaction results wins over connection results', () => {
+    this.connection.results.add({ name: 'spf' }, { result: 'NEUTRAL' })
+    this.connection.transaction.results.add({ name: 'spf' }, { result: 'PASS' })
+    const opts = this.plugin.get_options(this.connection)
+    assert.deepEqual(opts.headers.SPF, { result: 'pass' })
+  })
+
+  it('falls back to connection SPF when transaction has none', () => {
+    this.connection.results.add({ name: 'spf' }, { result: 'FAIL' })
+    const opts = this.plugin.get_options(this.connection)
+    assert.deepEqual(opts.headers.SPF, { result: 'fail' })
+  })
+
+  it('sets From from mail_from', () => {
+    this.connection.transaction.mail_from = new Address.Address(
+      '<sender@example.com>',
+    )
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.From, 'sender@example.com')
+  })
+
+  it('single rcpt gets Rcpt and Deliver-To', () => {
+    this.connection.transaction.rcpt_to = [
+      new Address.Address('<one@example.com>'),
+    ]
+    const opts = this.plugin.get_options(this.connection)
+    assert.deepEqual(opts.headers.Rcpt, ['one@example.com'])
+    assert.equal(opts.headers['Deliver-To'], 'one@example.com')
+  })
+
+  it('multi rcpt gets Rcpt array only (no Deliver-To)', () => {
+    this.connection.transaction.rcpt_to = [
+      new Address.Address('<one@example.com>'),
+      new Address.Address('<two@example.com>'),
+    ]
+    const opts = this.plugin.get_options(this.connection)
+    assert.deepEqual(opts.headers.Rcpt, ['one@example.com', 'two@example.com'])
+    assert.equal(opts.headers['Deliver-To'], undefined)
+  })
+
+  it('sets Queue-Id from transaction uuid', () => {
+    this.connection.transaction.uuid = 'ABC-123'
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers['Queue-Id'], 'ABC-123')
+  })
+
+  it('sets TLS headers when tls.enabled', () => {
+    this.connection.tls.enabled = true
+    this.connection.tls.cipher = {
+      name: 'TLS_AES_256_GCM_SHA384',
+      version: 'TLSv1.3',
+    }
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers['TLS-Cipher'], 'TLS_AES_256_GCM_SHA384')
+    assert.equal(opts.headers['TLS-Version'], 'TLSv1.3')
+  })
+
+  it('sets https transport options when scheme=https', () => {
+    this.plugin.cfg.main.scheme = 'https'
+    this.plugin.cfg.main.host = 'rspamd.example.com'
+    this.plugin.cfg.main.port = 443
+    this.plugin.cfg.tls.servername = 'scan.example.com'
+    this.plugin.cfg.tls.reject_unauthorized = false
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.protocol, 'https:')
+    assert.equal(opts.host, 'rspamd.example.com')
+    assert.equal(opts.port, 443)
+    assert.equal(opts.servername, 'scan.example.com')
+    assert.equal(opts.rejectUnauthorized, false)
+  })
+
+  it('loads https cert options from files', () => {
+    this.plugin.cfg.main.scheme = 'https'
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rspamd-test-'))
+    const caFile = path.join(dir, 'ca.pem')
+    const certFile = path.join(dir, 'cert.pem')
+    const keyFile = path.join(dir, 'key.pem')
+    try {
+      fs.writeFileSync(caFile, 'ca')
+      fs.writeFileSync(certFile, 'cert')
+      fs.writeFileSync(keyFile, 'key')
+      this.plugin.cfg.tls.ca_file = caFile
+      this.plugin.cfg.tls.cert_file = certFile
+      this.plugin.cfg.tls.key_file = keyFile
+
+      const opts = this.plugin.get_options(this.connection)
+      assert.equal(opts.ca.toString(), 'ca')
+      assert.equal(opts.cert.toString(), 'cert')
+      assert.equal(opts.key.toString(), 'key')
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('sets rspamd settings controls', () => {
+    this.plugin.cfg.request.settings_id = 'uribl'
+    this.plugin.cfg.request.settings = '{"groups_enabled":["surbl"]}'
+    this.plugin.cfg.request.flags = 'groups,milter'
+    this.plugin.cfg.request.ext_urls = true
+    this.plugin.cfg.request.pass_all = true
+
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers['Settings-ID'], 'uribl')
+    assert.equal(opts.headers.Settings, '{"groups_enabled":["surbl"]}')
+    assert.equal(opts.headers.Pass, 'all')
+    assert.equal(opts.headers.Flags, 'groups,milter,ext_urls')
+  })
+
+  it('sets basic auth header', () => {
+    this.plugin.cfg.auth = {
+      basic_user: 'u',
+      basic_pass: 'p',
+    }
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.Authorization, 'Basic dTpw')
+  })
+
+  it('sets header auth from env var', () => {
+    process.env.RSPAMD_AUTH = 'Bearer abc123'
+    try {
+      this.plugin.cfg.auth = {
+        header: 'Authorization',
+        value_env: 'RSPAMD_AUTH',
+      }
+      const opts = this.plugin.get_options(this.connection)
+      assert.equal(opts.headers.Authorization, 'Bearer abc123')
+    } finally {
+      delete process.env.RSPAMD_AUTH
+    }
+  })
+
+  it('sets request_headers from config', () => {
+    this.plugin.cfg.request_headers = {
+      'MTA-Tag': 'outbound',
+      'X-API-Key': 'sekret',
+    }
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers['MTA-Tag'], 'outbound')
+    assert.equal(opts.headers['X-API-Key'], 'sekret')
+  })
+})
+
+describe('get_request_client', () => {
+  beforeEach(_set_up)
+
+  it('returns http client for http options', () => {
+    assert.equal(this.plugin.get_request_client({ protocol: 'http:' }), http)
+  })
+
+  it('returns https client for https options', () => {
+    assert.equal(this.plugin.get_request_client({ protocol: 'https:' }), https)
+  })
+
+  it('returns http client for socketPath', () => {
+    assert.equal(
+      this.plugin.get_request_client({ socketPath: '/tmp/rspamd.sock' }),
+      http,
+    )
+  })
+})
+
+describe('get_smtp_message', () => {
+  beforeEach(_set_up)
+
+  it('returns undefined when smtp_message disabled', () => {
+    this.plugin.cfg.smtp_message.enabled = false
+    assert.equal(
+      this.plugin.get_smtp_message({
+        data: { messages: { smtp_message: 'x' } },
+      }),
+      undefined,
+    )
+  })
+
+  it('returns undefined when data.messages missing', () => {
+    assert.equal(this.plugin.get_smtp_message({ data: {} }), undefined)
+  })
+
+  it('returns undefined when messages is not an object', () => {
+    assert.equal(
+      this.plugin.get_smtp_message({ data: { messages: 'string' } }),
+      undefined,
+    )
+  })
+
+  it('returns smtp_message when present', () => {
+    assert.equal(
+      this.plugin.get_smtp_message({
+        data: { messages: { smtp_message: 'rejected by policy' } },
+      }),
+      'rejected by policy',
+    )
+  })
+})
+
+describe('do_rewrite', () => {
+  beforeEach(_set_up)
+
+  it('returns false when rewrite_subject disabled', () => {
+    this.plugin.cfg.rewrite_subject.enabled = false
+    assert.equal(
+      this.plugin.do_rewrite(this.connection, { action: 'rewrite subject' }),
+      false,
+    )
+  })
+
+  it('returns false when action is not rewrite subject', () => {
+    assert.equal(
+      this.plugin.do_rewrite(this.connection, { action: 'add header' }),
+      false,
+    )
+  })
+
+  it('substitutes %s with old Subject', () => {
+    this.connection.transaction.header.add('Subject', 'Hello there')
+    this.plugin.do_rewrite(this.connection, {
+      action: 'rewrite subject',
+      subject: 'TAG: %s',
+    })
+    assert.equal(
+      this.connection.transaction.header.get('Subject'),
+      'TAG: Hello there',
+    )
+  })
+
+  it('uses cfg.subject when data.subject absent', () => {
+    this.connection.transaction.header.add('Subject', 'Hi')
+    this.plugin.cfg.subject = '[X] %s'
+    this.plugin.do_rewrite(this.connection, { action: 'rewrite subject' })
+    assert.equal(this.connection.transaction.header.get('Subject'), '[X] Hi')
+  })
+
+  it('substitutes with empty string when no old Subject', () => {
+    this.plugin.do_rewrite(this.connection, {
+      action: 'rewrite subject',
+      subject: 'TAG: %s',
+    })
+    assert.equal(this.connection.transaction.header.get('Subject'), 'TAG: ')
+  })
+})
+
+describe('add_dkim_header', () => {
+  beforeEach(_set_up)
+
+  it('no-op when dkim disabled', () => {
+    this.plugin.cfg.dkim.enabled = false
+    this.plugin.add_dkim_header(this.connection, {
+      'dkim-signature': 'v=1; a=rsa-sha256;...',
+    })
+    assert.equal(this.connection.transaction.header.get('DKIM-Signature'), '')
+  })
+
+  it('no-op when no signature in data', () => {
+    this.plugin.cfg.dkim.enabled = true
+    this.plugin.add_dkim_header(this.connection, {})
+    assert.equal(this.connection.transaction.header.get('DKIM-Signature'), '')
+  })
+
+  it('adds header when enabled and signature present', () => {
+    this.plugin.cfg.dkim.enabled = true
+    this.plugin.add_dkim_header(this.connection, {
+      'dkim-signature': 'v=1; a=rsa-sha256; d=example.com',
+    })
+    assert.equal(
+      this.connection.transaction.header.get('DKIM-Signature'),
+      'v=1; a=rsa-sha256; d=example.com',
+    )
+  })
+})
+
+describe('do_milter_headers', () => {
+  beforeEach(_set_up)
+
+  it('no-op when rmilter_headers disabled', () => {
+    this.plugin.cfg.rmilter_headers.enabled = false
+    this.plugin.do_milter_headers(this.connection, {
+      milter: { add_headers: { 'X-Foo': 'bar' } },
+    })
+    assert.equal(this.connection.transaction.header.get('X-Foo'), '')
+  })
+
+  it('no-op when data.milter absent', () => {
+    this.plugin.do_milter_headers(this.connection, {})
+    // nothing to assert beyond no throw
+    assert.ok(true)
+  })
+
+  it('removes headers listed in remove_headers', () => {
+    this.connection.transaction.header.add('X-Drop', 'kill me')
+    this.plugin.do_milter_headers(this.connection, {
+      milter: { remove_headers: { 'X-Drop': 1 } },
+    })
+    assert.equal(this.connection.transaction.header.get('X-Drop'), '')
+  })
+
+  it('adds string header value', () => {
+    this.plugin.do_milter_headers(this.connection, {
+      milter: { add_headers: { 'X-Str': 'plain' } },
+    })
+    assert.equal(this.connection.transaction.header.get('X-Str'), 'plain')
+  })
+
+  it('adds {value: ...} object value', () => {
+    this.plugin.do_milter_headers(this.connection, {
+      milter: { add_headers: { 'X-Obj': { value: 'wrapped' } } },
+    })
+    assert.equal(this.connection.transaction.header.get('X-Obj'), 'wrapped')
+  })
+
+  it('adds each entry in an array of strings', () => {
+    this.plugin.do_milter_headers(this.connection, {
+      milter: { add_headers: { 'X-Arr': ['a', 'b'] } },
+    })
+    assert.deepEqual(this.connection.transaction.header.get_all('X-Arr'), [
+      'a',
+      'b',
+    ])
+  })
+
+  it('adds each entry in an array of objects', () => {
+    this.plugin.do_milter_headers(this.connection, {
+      milter: {
+        add_headers: { 'X-Arr': [{ value: 'a' }, { value: 'b' }] },
+      },
+    })
+    assert.deepEqual(this.connection.transaction.header.get_all('X-Arr'), [
+      'a',
+      'b',
+    ])
+  })
+
+  it('adds mixed array of strings and objects', () => {
+    this.plugin.do_milter_headers(this.connection, {
+      milter: { add_headers: { 'X-Arr': ['s', { value: 'o' }] } },
+    })
+    assert.deepEqual(this.connection.transaction.header.get_all('X-Arr'), [
+      's',
+      'o',
+    ])
+  })
+
+  it('does not throw on circular-ref add_headers payload', () => {
+    const add_headers = { 'X-OK': 'kept' }
+    add_headers.self = add_headers // cycle in JSON.stringify
+    assert.doesNotThrow(() => {
+      this.plugin.do_milter_headers(this.connection, {
+        milter: { add_headers },
+      })
+    })
+  })
+})
+
+describe('wants_reject', () => {
+  beforeEach(_set_up)
+
+  it('returns false when action is not reject', () => {
+    assert.equal(
+      this.plugin.wants_reject(this.connection, { action: 'add header' }),
+      false,
+    )
+  })
+
+  it('authed + reject.authenticated=false → false', () => {
+    this.connection.notes.auth_user = 'u'
+    this.plugin.cfg.reject.authenticated = false
+    assert.equal(
+      this.plugin.wants_reject(this.connection, { action: 'reject' }),
+      false,
+    )
+  })
+
+  it('authed + reject.authenticated=true → true', () => {
+    this.connection.notes.auth_user = 'u'
+    this.plugin.cfg.reject.authenticated = true
+    assert.equal(
+      this.plugin.wants_reject(this.connection, { action: 'reject' }),
+      true,
+    )
+  })
+
+  it('anon + reject.spam=false → false', () => {
+    this.plugin.cfg.reject.spam = false
+    assert.equal(
+      this.plugin.wants_reject(this.connection, { action: 'reject' }),
+      false,
+    )
+  })
+
+  it('anon + reject.spam=true → true', () => {
+    this.plugin.cfg.reject.spam = true
+    assert.equal(
+      this.plugin.wants_reject(this.connection, { action: 'reject' }),
+      true,
+    )
+  })
+})
+
+describe('get_clean', () => {
+  beforeEach(_set_up)
+
+  it('maps symbols name+score to clean.symbols dict', () => {
+    const clean = this.plugin.get_clean(
+      { symbols: { FOO: { name: 'FOO', score: 1.5 } } },
+      this.connection,
+    )
+    assert.deepEqual(clean.symbols, { FOO: 1.5 })
+  })
+
+  it('copies scalar action/is_skipped/required_score/score keys', () => {
+    const clean = this.plugin.get_clean(
+      {
+        action: 'no action',
+        is_skipped: false,
+        required_score: 5,
+        score: 1.1,
+      },
+      this.connection,
+    )
+    assert.equal(clean.action, 'no action')
+    assert.equal(clean.is_skipped, false)
+    assert.equal(clean.required_score, 5)
+    assert.equal(clean.score, 1.1)
+  })
+
+  it('collapses urls array to comma-separated string', () => {
+    const clean = this.plugin.get_clean(
+      { urls: ['http://a/', 'http://b/'] },
+      this.connection,
+    )
+    assert.equal(clean.urls, 'http://a/,http://b/')
+  })
+
+  it('collapses emails array to comma-separated string', () => {
+    const clean = this.plugin.get_clean(
+      { emails: ['a@x', 'b@x'] },
+      this.connection,
+    )
+    assert.equal(clean.emails, 'a@x,b@x')
+  })
+
+  it('collapses messages dict to "k : v" CSV', () => {
+    // Fix for the dead-code bug where the join() result was discarded.
+    const clean = this.plugin.get_clean(
+      { messages: { smtp_message: 'rejected', other: 'note' } },
+      this.connection,
+    )
+    assert.equal(clean.messages, 'smtp_message : rejected,other : note')
+  })
+})
+
+describe('hook_data_post success paths', () => {
+  let server
+
+  beforeEach((t, done) => {
+    this.plugin = new fixtures.plugin('rspamd')
+    this.plugin.register()
+    this.connection = connection.createConnection()
+    this.connection.init_transaction()
+    const txn = this.connection.transaction
+    txn.mail_from = new Address.Address('<m@example.com>')
+    txn.rcpt_to = [new Address.Address('<r@example.com>')]
+    txn.uuid = 'TEST-UUID'
+    txn.message_stream.add_line('Header: 1\r\n')
+    txn.message_stream.add_line('\r\n')
+    txn.message_stream.add_line('Body\r\n')
+    txn.message_stream.add_line_end(done)
+  })
+
+  afterEach((t, done) => {
+    if (server) server.close(done)
+    else done()
+  })
+
+  const startStub = (jsonOrRaw, cb) => {
+    server = http.createServer((req, res) => {
+      req.resume() // drain the request body
+      req.on('end', () => {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(
+          typeof jsonOrRaw === 'string' ? jsonOrRaw : JSON.stringify(jsonOrRaw),
+        )
+      })
+    })
+    server.listen(0, '127.0.0.1', () => {
+      this.plugin.cfg.main.host = '127.0.0.1'
+      this.plugin.cfg.main.port = server.address().port
+      cb()
+    })
+  }
+
+  it('action=soft reject → DENYSOFT', (t, done) => {
+    startStub({ action: 'soft reject', score: 5, required_score: 10 }, () => {
+      this.plugin.hook_data_post((code) => {
+        assert.equal(code, DENYSOFT)
+        done()
+      }, this.connection)
+    })
+  })
+
+  it('action=reject → DENY (anon, reject.spam=true)', (t, done) => {
+    startStub({ action: 'reject', score: 99, required_score: 10 }, () => {
+      this.plugin.hook_data_post((code) => {
+        assert.equal(code, DENY)
+        done()
+      }, this.connection)
+    })
+  })
+
+  it('action=add header → CONT with headers added', (t, done) => {
+    startStub(
+      { action: 'add header', score: 5, required_score: 10, symbols: {} },
+      () => {
+        this.plugin.cfg.main.add_headers = 'sometimes'
+        this.plugin.hook_data_post((code) => {
+          assert.equal(code, undefined)
+          assert.deepEqual(
+            this.connection.transaction.header.headers['x-rspamd-score'],
+            ['5'],
+          )
+          done()
+        }, this.connection)
+      },
+    )
+  })
+
+  it('empty {} response → CONT', (t, done) => {
+    startStub({}, () => {
+      this.plugin.hook_data_post((code) => {
+        assert.equal(code, undefined)
+        done()
+      }, this.connection)
+    })
+  })
+
+  it('bad JSON + defer.error=true → DENYSOFT', (t, done) => {
+    startStub('not json at all', () => {
+      this.plugin.cfg.defer.error = true
+      this.plugin.hook_data_post((code) => {
+        assert.equal(code, DENYSOFT)
+        done()
+      }, this.connection)
+    })
+  })
+
+  it('bad JSON + defer.error=false → CONT', (t, done) => {
+    startStub('not json at all', () => {
+      this.plugin.cfg.defer.error = false
+      this.plugin.hook_data_post((code) => {
+        assert.equal(code, undefined)
         done()
       }, this.connection)
     })


### PR DESCRIPTION
- feat: add HTTPS support with configurable TLS options
  - fixes #37
- feat: move more protocol handing into rspamd.ini
- feat: expanded protocol-level control over requests
  - Settings-ID, Settings, Flags, Pass, Raw, URL-Format, etc
  - fixes #24 
- refactor: reduce complexity, use ES2024 idioms
- fix(get_clean): preserve messages dictionary, was discarding the join result
- fix(do_milter_headers):
  - logerror typo (was errorlog)
  - move JSON.stringify into try so circular references don't crash

Checklist:

- [x] docs updated
- [x] tests updated
- [x] Changes.md updated
