### PR TITLE
fix(set_envelope): tolerate method- and property-style Address.address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- fix(set_envelope): tolerate both Address APIs; on Haraka <= 3.1.7
+  (address-rfc2821, .address is a method) the property read leaked function
+  source into From/Rcpt, crashing the scan on Node >= 20 (ERR_INVALID_CHAR)
+  and raising BROKEN_HEADERS in rspamd on every message
+
 ### [1.6.1] - 2026-06-20
 
 - deps(test-fixtures): update to 1.7.0 syntax (#56, #57)

--- a/index.js
+++ b/index.js
@@ -195,14 +195,27 @@ function set_spf(options, connection) {
   if (spf?.result) options.headers.SPF = { result: spf.result.toLowerCase() }
 }
 
+// The Address objects come from the host Haraka: @haraka/email-address
+// (Haraka >= 3.2.0) exposes .address as a string property, address-rfc2821
+// (Haraka <= 3.1.7) as a method. Reading the method as a property leaks the
+// function's source into the From/Rcpt headers: rspamd flags every message
+// BROKEN_HEADERS and Node >= 20 rejects the multiline header value with
+// ERR_INVALID_CHAR, aborting the scan. Tolerate both APIs.
+function get_address(a) {
+  if (a == null) return undefined
+  if (typeof a.address === 'function') return a.address()
+  if (a.address != null) return String(a.address)
+  return typeof a.toString === 'function' ? a.toString() : undefined
+}
+
 function set_envelope(options, connection) {
   const txn = connection.transaction
-  const from = txn.mail_from?.address?.toString()
+  const from = get_address(txn.mail_from)
   if (from) options.headers.From = from
 
   const rcpts = txn.rcpt_to
   if (rcpts?.length) {
-    options.headers.Rcpt = rcpts.map((r) => r.address)
+    options.headers.Rcpt = rcpts.map(get_address)
     // for per-user options
     if (rcpts.length === 1)
       options.headers['Deliver-To'] = options.headers.Rcpt[0]

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "devDependencies": {
     "@haraka/email-address": "^3.1.6",
     "@haraka/eslint-config": "^3.0.0",
+    "address-rfc2821": "^2.2.1",
     "haraka-test-fixtures": "^1.7.1"
   },
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ const { PassThrough } = require('node:stream')
 const { afterEach, beforeEach, describe, it } = require('node:test')
 
 const { Address } = require('@haraka/email-address')
+const { Address: Rfc2821Address } = require('address-rfc2821')
 const { makeConnection, makePlugin } = require('haraka-test-fixtures')
 
 const _set_up = (t, done) => {
@@ -403,6 +404,21 @@ describe('get_options', () => {
     this.connection.transaction.mail_from = new Address('<sender@example.com>')
     const opts = this.plugin.get_options(this.connection)
     assert.equal(opts.headers.From, 'sender@example.com')
+  })
+
+  it('extracts bare addresses from legacy address-rfc2821 objects', () => {
+    // Haraka <= 3.1.7 passes address-rfc2821 Address objects, where .address
+    // is a method — reading it as a property yields the function itself
+    this.connection.transaction.mail_from = new Rfc2821Address(
+      '<sender@example.com>',
+    )
+    this.connection.transaction.rcpt_to = [
+      new Rfc2821Address('<one@example.com>'),
+    ]
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.From, 'sender@example.com')
+    assert.deepEqual(opts.headers.Rcpt, ['one@example.com'])
+    assert.equal(opts.headers['Deliver-To'], 'one@example.com')
   })
 
   it('single rcpt gets Rcpt and Deliver-To', () => {


### PR DESCRIPTION
## Problem

`transaction.mail_from` / `rcpt_to` hold Address objects created by the host Haraka, and the two parsers in circulation expose `address` differently:

- `@haraka/email-address` (Haraka >= 3.2.0): `address` is a string property
- `address-rfc2821` (every released Haraka <= 3.1.7): `address()` is a method

Since v1.6.0 (#55) the plugin reads it as a property, so on Haraka <= 3.1.7 `txn.mail_from?.address?.toString()` returns the accessor function's **source code** and `rcpts.map((r) => r.address)` returns function references. That garbage envelope value is forwarded to rspamd as HTTP request headers, with two production consequences:

1. **Scan crash.** Node >= 20 validates header values strictly; the multiline function source throws `ERR_INVALID_CHAR` (`Invalid character in header content ["From"]`), the data_post hook gets no verdict back, and in a reject-after-forward setup every message sails through unscanned.
2. **Score inflation.** rspamd cannot parse the value as an envelope address and sets its protocol-level BROKEN_HEADERS flag on the message. Observed in production: the flag fired on ~92% of mail at +8 points per message (genuine baseline ~2.4%), silently poisoning scores and any greylist/quarantine thresholds. (Distinguishable from the `headers_checks` symbol of the same name: the flag carries empty options, and a manual rescan of the same raw message does not raise it.)

Deploying this fix in production returned BROKEN_HEADERS to its ~2.4% genuine baseline and eliminated the crashes.

## Fix

Extract the bare address through a small helper that calls `address` when it is a function and stringifies it otherwise, so the plugin works on either side of the Haraka 3.2.0 parser migration. The regression test uses a real `address-rfc2821` Address (added as a devDependency — it is what every released Haraka <= 3.1.7 actually passes) and fails without the fix.

The same root cause exists in haraka-plugin-access; a matching PR is filed there.
