### PR TITLE
feat: support rspamd's /checkv3 protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Unreleased
 
+- feat: support rspamd's /checkv3 protocol (opt-in via `path = /checkv3`);
+  message and metadata travel as multipart/form-data body parts, keeping
+  envelope values out of HTTP request headers
+
 ### [1.6.1] - 2026-06-20
 
 - deps(test-fixtures): update to 1.7.0 syntax (#56, #57)

--- a/README.md
+++ b/README.md
@@ -275,19 +275,18 @@ aborting the scan, and it enlarges the header-injection surface.
 
 Setting `path = /checkv3` switches to rspamd's v3 protocol (rspamd >= 4.1):
 the message and a JSON metadata object are posted as two `multipart/form-data`
-body parts, so no per-message value passes through HTTP header parsing. The
-reply is requested as flat JSON and is identical to /checkv2, as are all
-plugin actions and added headers.
+body parts. The reply is flat JSON, identical to /checkv2.
 
 Notes:
 
-- `request.settings` must be a JSON object (it is passed structured, not as
-  a raw header). A value rspamd would accept as UCL but that is not valid
-  JSON is ignored with a logged error.
+- `request.settings` must be a JSON object (it is passed structured). A value
+  rspamd would accept as UCL but is invalid JSON is logged as an error.
 - `request.url_format` has no v3 equivalent; use `request.ext_urls` instead.
 - the SPF result hint is not forwarded (rspamd evaluates SPF itself).
 - entries in `request_headers` are carried in the metadata `headers` key and
   still surface as request headers on the rspamd side.
+- Memory use will increase with v3 as the entire email is spooled in memory
+  before being sent to rspamd.
 
 <!-- leave these buried at the bottom of the document -->
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,9 @@ rspamd.ini
 
   Default: /checkv2
 
-  HTTP path for rspamd checks.
+  HTTP path for rspamd checks. Set to `/checkv3` to carry the per-message
+  metadata in the request body instead of HTTP headers — see
+  [the checkv3 protocol](#the-checkv3-protocol) below.
 
 - add_headers
 
@@ -261,6 +263,31 @@ rspamd.ini
   Default: 29 seconds
 
   How long to wait for a response from rspamd.
+
+## The checkv3 protocol
+
+With the default `path = /checkv2`, per-message metadata (envelope from,
+recipients, client IP, HELO, hostname, authenticated user, queue id, TLS
+info, settings, flags) is sent to rspamd as HTTP request headers. Header
+transport is fragile: Node's strict header validation rejects values with
+non-ASCII characters (spam routinely carries non-ASCII MAIL FROM / RCPT),
+aborting the scan, and it enlarges the header-injection surface.
+
+Setting `path = /checkv3` switches to rspamd's v3 protocol (rspamd >= 4.1):
+the message and a JSON metadata object are posted as two `multipart/form-data`
+body parts, so no per-message value passes through HTTP header parsing. The
+reply is requested as flat JSON and is identical to /checkv2, as are all
+plugin actions and added headers.
+
+Notes:
+
+- `request.settings` must be a JSON object (it is passed structured, not as
+  a raw header). A value rspamd would accept as UCL but that is not valid
+  JSON is ignored with a logged error.
+- `request.url_format` has no v3 equivalent; use `request.ext_urls` instead.
+- the SPF result hint is not forwarded (rspamd evaluates SPF itself).
+- entries in `request_headers` are carried in the metadata `headers` key and
+  still surface as request headers on the rspamd side.
 
 <!-- leave these buried at the bottom of the document -->
 

--- a/config/rspamd.ini
+++ b/config/rspamd.ini
@@ -2,6 +2,8 @@
 ;port = 11333
 ;scheme = http
 ;path = /checkv2
+; /checkv3 sends metadata in the request body, not HTTP headers (rspamd >= 4.1)
+;path = /checkv3
 ;unix_socket = /path/to/your/rspamd-client.sock
 ;add_headers = sometimes
 

--- a/index.js
+++ b/index.js
@@ -439,7 +439,8 @@ function send_multipart_request(plugin, connection, ctx, options, start) {
         'Content-Type: application/json\r\n\r\n' +
         `${metadata}\r\n` +
         `--${boundary}\r\n` +
-        'Content-Disposition: form-data; name="message"\r\n\r\n',
+        'Content-Disposition: form-data; name="message"\r\n' +
+        'Content-Type: message/rfc822\r\n\r\n',
     ),
   ]
 

--- a/index.js
+++ b/index.js
@@ -1,9 +1,11 @@
 'use strict'
 
 // node built-ins
+const crypto = require('node:crypto')
 const fs = require('node:fs')
 const http = require('node:http')
 const https = require('node:https')
+const { Writable } = require('node:stream')
 
 // haraka libs
 const DSN = require('haraka-dsn')
@@ -69,6 +71,17 @@ exports.get_options = function (connection) {
   // https://github.com/rspamd/rspamd/blob/master/rules/headers_checks.lua
   const options = { headers: {}, path: this.cfg.main.path, method: 'POST' }
   set_transport(options, this.cfg)
+
+  if (wants_checkv3(this.cfg)) {
+    // rspamd ignores per-message HTTP request headers on /checkv3: the
+    // metadata travels as a JSON part of the multipart body instead (see
+    // get_v3_metadata). Accept selects the flat JSON reply, the same shape
+    // /checkv2 returns.
+    set_upstream_auth(options, this.cfg)
+    options.headers.Accept = 'application/json'
+    return options
+  }
+
   set_protocol(options, this.cfg)
   set_auth(options, connection)
   set_remote(options, connection)
@@ -217,6 +230,89 @@ function set_tls(options, connection) {
   options.headers['TLS-Version'] = connection.tls.cipher.version
 }
 
+function wants_checkv3(cfg) {
+  return cfg.main.path === '/checkv3'
+}
+
+// Per-message metadata for /checkv3. Everything the set_* helpers above put
+// into HTTP request headers for /checkv2 rides in a JSON body part instead,
+// so envelope values never pass through HTTP header validation: a non-ASCII
+// MAIL FROM / RCPT no longer aborts the scan with ERR_INVALID_CHAR on
+// Node >= 20, nor triggers rspamd's BROKEN_HEADERS.
+exports.get_v3_metadata = function (connection) {
+  const md = {}
+  set_v3_remote(md, connection)
+  set_v3_envelope(md, connection)
+  set_v3_tls(md, connection)
+  set_v3_controls(md, this.cfg, connection, this)
+  return md
+}
+
+function set_v3_remote(md, connection) {
+  if (connection.remote.ip) md.ip = connection.remote.ip
+  const fcrdns = connection.results.get('fcrdns')
+  const host = fcrdns?.fcrdns?.[0] ?? connection.remote.host
+  if (host) md.hostname = host
+  if (connection.hello.host) md.helo = connection.hello.host
+  if (connection.notes.auth_user) md.user = connection.notes.auth_user
+}
+
+function set_v3_envelope(md, connection) {
+  const txn = connection.transaction
+  const from = txn.mail_from?.address?.toString()
+  if (from) md.from = from
+
+  const rcpts = txn.rcpt_to
+  if (rcpts?.length) {
+    md.rcpt = rcpts.map((r) => r.address)
+    // for per-user options
+    if (rcpts.length === 1) md.deliver_to = md.rcpt[0]
+  }
+
+  if (txn.uuid) md.queue_id = txn.uuid
+}
+
+function set_v3_tls(md, connection) {
+  if (!connection.tls.enabled) return
+  md.tls = {
+    cipher: connection.tls.cipher.name,
+    version: connection.tls.cipher.version,
+  }
+}
+
+function set_v3_controls(md, cfg, connection, plugin) {
+  const req = cfg.request ?? {}
+  if (req.settings_id) md.settings_id = req.settings_id
+  if (req.settings) set_v3_settings(md, req.settings, connection, plugin)
+  if (req.raw) md.raw = true
+
+  // pass_all is a protocol flag in the metadata, not a Pass header
+  const flags = new Set(get_flags(req))
+  if (req.pass_all) flags.add('pass_all')
+  if (flags.size) md.flags = [...flags]
+
+  // custom request headers surface as task request headers via metadata
+  const headers = cfg.request_headers
+  if (!headers || typeof headers !== 'object') return
+  for (const [key, value] of Object.entries(headers)) {
+    if (!value) continue
+    ;(md.headers ??= {})[key] = `${value}`
+  }
+}
+
+function set_v3_settings(md, settings, connection, plugin) {
+  // the metadata settings key must be a JSON object; rspamd.ini has a string
+  try {
+    const parsed = JSON.parse(settings)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('not an object')
+    }
+    md.settings = parsed
+  } catch (err) {
+    connection.logerror(plugin, `ignoring request.settings: ${err.message}`)
+  }
+}
+
 exports.get_smtp_message = function (r) {
   if (!this.cfg.smtp_message.enabled) return
   const messages = r?.data?.messages
@@ -301,6 +397,19 @@ exports.rspamd_data_post = function (next, connection) {
   )
 
   const options = plugin.get_options(connection)
+
+  if (wants_checkv3(plugin.cfg)) {
+    send_multipart_request(plugin, connection, ctx, options, start)
+    return
+  }
+
+  connection.transaction.message_stream.pipe(
+    start_request(plugin, connection, ctx, options, start),
+  )
+  // pipe calls req.end() asynchronously
+}
+
+function start_request(plugin, connection, ctx, options, start) {
   const request_client = plugin.get_request_client(options)
   ctx.req = request_client.request(options, (res) => {
     let rawData = ''
@@ -311,9 +420,44 @@ exports.rspamd_data_post = function (next, connection) {
   })
 
   ctx.req.on('error', (err) => on_request_error(plugin, connection, ctx, err))
+  return ctx.req
+}
 
-  connection.transaction.message_stream.pipe(ctx.req)
-  // pipe calls req.end() asynchronously
+// /checkv3 request: multipart/form-data with a JSON metadata part and the
+// raw message part. The body is buffered so it can be framed with a
+// Content-Length and the closing boundary appended after the message stream
+// ends.
+function send_multipart_request(plugin, connection, ctx, options, start) {
+  const boundary = `haraka-rspamd-${crypto.randomBytes(16).toString('hex')}`
+  options.headers['Content-Type'] = `multipart/form-data; boundary=${boundary}`
+
+  const metadata = JSON.stringify(plugin.get_v3_metadata(connection))
+  const chunks = [
+    Buffer.from(
+      `--${boundary}\r\n` +
+        'Content-Disposition: form-data; name="metadata"\r\n' +
+        'Content-Type: application/json\r\n\r\n' +
+        `${metadata}\r\n` +
+        `--${boundary}\r\n` +
+        'Content-Disposition: form-data; name="message"\r\n\r\n',
+    ),
+  ]
+
+  const collector = new Writable({
+    write(chunk, encoding, cb) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk, encoding))
+      cb()
+    },
+  })
+  collector.on('finish', () => {
+    if (ctx.calledNext) return // timed out while collecting
+    chunks.push(Buffer.from(`\r\n--${boundary}--\r\n`))
+    const body = Buffer.concat(chunks)
+    options.headers['Content-Length'] = body.length
+    start_request(plugin, connection, ctx, options, start).end(body)
+  })
+  collector.on('error', (err) => on_request_error(plugin, connection, ctx, err))
+  connection.transaction.message_stream.pipe(collector)
 }
 
 function make_request_context(plugin, connection, next) {

--- a/test/index.js
+++ b/test/index.js
@@ -935,3 +935,188 @@ describe('rspamd_data_post success paths', () => {
     })
   })
 })
+
+describe('checkv3 options and metadata', () => {
+  beforeEach(_set_up)
+
+  it('omits per-message headers from request options', () => {
+    this.plugin.cfg.main.path = '/checkv3'
+    this.connection.remote.ip = '203.0.113.5'
+    this.connection.hello.host = 'helo.example.com'
+    this.connection.notes.auth_user = 'bob@example.com'
+    this.connection.transaction.mail_from = new Address('<sender@example.com>')
+    this.plugin.cfg.request.settings_id = 'uribl'
+
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.path, '/checkv3')
+    assert.equal(opts.headers.Accept, 'application/json')
+    const banned = ['From', 'Rcpt', 'IP', 'Hostname', 'Helo', 'User']
+    for (const name of [...banned, 'Settings-ID', 'Queue-Id']) {
+      assert.equal(opts.headers[name], undefined, `${name} must not be sent`)
+    }
+  })
+
+  it('keeps upstream auth headers', () => {
+    this.plugin.cfg.main.path = '/checkv3'
+    this.plugin.cfg.auth = { basic_user: 'u', basic_pass: 'p' }
+    const opts = this.plugin.get_options(this.connection)
+    assert.equal(opts.headers.Authorization, 'Basic dTpw')
+  })
+
+  it('maps the v2 request headers into metadata', () => {
+    this.connection.remote.ip = '203.0.113.5'
+    this.connection.remote.host = 'fallback.example.com'
+    this.connection.hello.host = 'helo.example.com'
+    this.connection.notes.auth_user = 'bob@example.com'
+    this.connection.tls.enabled = true
+    this.connection.tls.cipher = {
+      name: 'TLS_AES_256_GCM_SHA384',
+      version: 'TLSv1.3',
+    }
+    const txn = this.connection.transaction
+    txn.mail_from = new Address('<sender@example.com>')
+    txn.rcpt_to = [new Address('<one@example.com>')]
+    txn.uuid = 'ABC-123'
+    this.plugin.cfg.request.settings_id = 'uribl'
+    this.plugin.cfg.request.settings = '{"groups_enabled":["surbl"]}'
+    this.plugin.cfg.request.flags = 'groups,milter'
+    this.plugin.cfg.request.pass_all = true
+    this.plugin.cfg.request.raw = true
+    this.plugin.cfg.request_headers = { 'MTA-Tag': 'outbound' }
+
+    assert.deepEqual(this.plugin.get_v3_metadata(this.connection), {
+      ip: '203.0.113.5',
+      hostname: 'fallback.example.com',
+      helo: 'helo.example.com',
+      user: 'bob@example.com',
+      from: 'sender@example.com',
+      rcpt: ['one@example.com'],
+      deliver_to: 'one@example.com',
+      queue_id: 'ABC-123',
+      tls: { cipher: 'TLS_AES_256_GCM_SHA384', version: 'TLSv1.3' },
+      settings_id: 'uribl',
+      settings: { groups_enabled: ['surbl'] },
+      raw: true,
+      flags: ['groups', 'milter', 'pass_all'],
+      headers: { 'MTA-Tag': 'outbound' },
+    })
+  })
+
+  it('drops request.settings that is not a JSON object', () => {
+    this.plugin.cfg.request.settings = 'symbols_enabled = ["FOO"]'
+    const md = this.plugin.get_v3_metadata(this.connection)
+    assert.equal(md.settings, undefined)
+  })
+})
+
+describe('rspamd_data_post checkv3', () => {
+  let server
+
+  beforeEach((t, done) => {
+    this.plugin = makePlugin('rspamd')
+    this.connection = makeConnection({
+      mailFrom: 'm@example.com',
+      rcptTo: ['r@example.com'],
+    })
+    const txn = this.connection.transaction
+    txn.uuid = 'TEST-UUID'
+    txn.message_stream.add_line('Header: 1\r\n')
+    txn.message_stream.add_line('\r\n')
+    txn.message_stream.add_line('Body\r\n')
+    txn.message_stream.add_line_end(done)
+  })
+
+  afterEach((t, done) => {
+    if (server) server.close(done)
+    else done()
+  })
+
+  const startV3Stub = (reply, onRequest, cb) => {
+    server = http.createServer((req, res) => {
+      const chunks = []
+      req.on('data', (c) => chunks.push(c))
+      req.on('end', () => {
+        onRequest(req, Buffer.concat(chunks))
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify(reply))
+      })
+    })
+    server.listen(0, '127.0.0.1', () => {
+      this.plugin.cfg.main.host = '127.0.0.1'
+      this.plugin.cfg.main.port = server.address().port
+      this.plugin.cfg.main.path = '/checkv3'
+      cb()
+    })
+  }
+
+  const get_parts = (req, body) => {
+    const boundary = req.headers['content-type'].match(/boundary=(.+)$/)[1]
+    const parts = {}
+    for (const seg of body
+      .toString('utf8')
+      .split(`--${boundary}`)
+      .slice(1, -1)) {
+      const body_at = seg.indexOf('\r\n\r\n')
+      const head = seg.slice(0, body_at)
+      const data = seg.slice(body_at + 4)
+      parts[head.match(/name="([^"]+)"/)[1]] = data.slice(0, -2) // framing CRLF
+    }
+    return parts
+  }
+
+  it('posts multipart metadata + message and honors the verdict', (t, done) => {
+    let seen
+    startV3Stub(
+      { action: 'reject', score: 99, required_score: 10 },
+      (req, body) => {
+        seen = { req, body }
+      },
+      () => {
+        this.plugin.rspamd_data_post((code) => {
+          assert.equal(code, DENY)
+          assert.equal(seen.req.url, '/checkv3')
+          assert.equal(seen.req.headers.accept, 'application/json')
+          assert.ok(
+            seen.req.headers['content-type'].startsWith(
+              'multipart/form-data; boundary=',
+            ),
+          )
+          assert.equal(
+            Number(seen.req.headers['content-length']),
+            seen.body.length,
+          )
+          assert.equal(seen.req.headers.from, undefined)
+          assert.equal(seen.req.headers.rcpt, undefined)
+
+          const parts = get_parts(seen.req, seen.body)
+          const md = JSON.parse(parts.metadata)
+          assert.equal(md.from, 'm@example.com')
+          assert.deepEqual(md.rcpt, ['r@example.com'])
+          assert.equal(md.queue_id, 'TEST-UUID')
+          assert.equal(parts.message, 'Header: 1\r\n\r\nBody\r\n')
+          done()
+        }, this.connection)
+      },
+    )
+  })
+
+  it('carries a non-ASCII envelope that would crash header transport', (t, done) => {
+    // on /checkv2 this envelope throws ERR_INVALID_CHAR in the From header
+    this.connection.transaction.mail_from = new Address('<пример@example.com>')
+    let seen
+    startV3Stub(
+      { action: 'no action', score: 0, required_score: 10 },
+      (req, body) => {
+        seen = { req, body }
+      },
+      () => {
+        this.plugin.rspamd_data_post((code) => {
+          assert.equal(code, undefined)
+          const md = JSON.parse(get_parts(seen.req, seen.body).metadata)
+          assert.equal(md.from, 'пример@example.com')
+          done()
+        }, this.connection)
+      },
+    )
+  })
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1050,7 +1050,7 @@ describe('rspamd_data_post checkv3', () => {
   }
 
   const get_parts = (req, body) => {
-    const boundary = req.headers['content-type'].match(/boundary=(.+)$/)[1]
+    const boundary = req.headers['content-type'].match(/boundary=([^\s;]+)/)[1]
     const parts = {}
     for (const seg of body
       .toString('utf8')


### PR DESCRIPTION
Opt-in via path = /checkv3 (rspamd >= 4.1). The message and a JSON metadata object (envelope from/rcpt, ip, helo, hostname, user, queue id, TLS info, settings, flags) are posted as two multipart/form-data body parts, so no per-message value passes through HTTP header validation or parsing. That removes two failure modes inherent to header transport:

- Node >= 20 rejects non-ASCII header values with ERR_INVALID_CHAR, so any message with a non-ASCII MAIL FROM / RCPT (routine in spam) aborted the scan without a verdict
- a value rspamd cannot parse as an envelope address makes it flag the message BROKEN_HEADERS, distorting scores

The reply is requested as flat JSON (Accept: application/json) and is identical to /checkv2, so response handling is unchanged. Default behavior without the config change is untouched.

cherry picked from #60, closes #60