### PR TITLE
fix: serialize DSN object to string on soft_reject

### DIFF
--- a/index.js
+++ b/index.js
@@ -532,7 +532,7 @@ exports.decide_action = function (connection, r) {
   if (this.cfg.soft_reject.enabled && r.data.action === 'soft reject') {
     return [
       DENYSOFT,
-      DSN.sec_unauthorized(smtp_message || this.cfg.soft_reject.message, 451),
+      DSN.sec_unauthorized(smtp_message || this.cfg.soft_reject.message, 451).toString(),
     ]
   }
   if (this.wants_reject(connection, r.data)) {

--- a/test/index.js
+++ b/test/index.js
@@ -871,10 +871,11 @@ describe('rspamd_data_post success paths', () => {
     })
   }
 
-  it('action=soft reject → DENYSOFT', (t, done) => {
+  it('action=soft reject → DENYSOFT with string message', (t, done) => {
     startStub({ action: 'soft reject', score: 5, required_score: 10 }, () => {
-      this.plugin.rspamd_data_post((code) => {
+      this.plugin.rspamd_data_post((code, msg) => {
         assert.equal(code, DENYSOFT)
+        assert.equal(typeof msg, 'string', `message must be a string, got ${typeof msg}: ${msg}`)
         done()
       }, this.connection)
     })


### PR DESCRIPTION
## Problem

When `soft_reject.enabled` is true and rspamd returns a `soft reject` action, the plugin calls:

next(DENYSOFT, DSN.sec_unauthorized(...))

`DSN.sec_unauthorized()` returns a class instance that does not auto-serialize to string, causing Haraka to log `[object Object]` instead of a readable rejection message like `451 4.7.0 Try again later`.

## Fix

Added `.toString()` to serialize the DSN object before passing it to the callback:

DSN.sec_unauthorized(...).toString()

## Tests

Extended the existing `soft reject → DENYSOFT` test to assert that the second callback argument is a `string`, not an object. The test fails on the original code and passes with this fix.